### PR TITLE
Add change event generation endpoint

### DIFF
--- a/backend/src/controllers/changeEventsController.js
+++ b/backend/src/controllers/changeEventsController.js
@@ -1,0 +1,26 @@
+const axios = require('axios');
+
+/**
+ * Proxy to Python service for generating change events.
+ * Expects JSON body with:
+ *   - org_name: string
+ *   - scenario: "major" | "partial" | "well"
+ *   - optional overrides: itsm_tools, observability_tools, service_names, etc.
+ */
+exports.handleGenerateChangeEvents = async (req, res) => {
+  try {
+    const { org_name, scenario } = req.body;
+    if (!org_name || !scenario) {
+      return res.status(400).json({ message: 'org_name and scenario are required.' });
+    }
+    const payload = req.body;
+    const url = process.env.PYTHON_CHANGE_URL || 'http://localhost:5001/api/generate_change_events';
+    const response = await axios.post(url, payload);
+    return res.json(response.data);
+  } catch (error) {
+    console.error('Error generating change events:', error.response ? error.response.data : error.message);
+    const status = error.response?.status || 500;
+    const message = error.response?.data?.message || 'Internal server error';
+    return res.status(status).json({ message });
+  }
+};

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -22,13 +22,16 @@ app.options('/api/generate_sop', cors(corsOptions));
 app.options('/api/generate_sop/blended', cors(corsOptions));
 // Preflight CORS for diagnostics
 app.options('/api/generate_diagnostics', cors(corsOptions));
+app.options('/api/generate_change_events', cors(corsOptions));
 app.use(bodyParser.json());
 
 // Routes
 const generateRoutes = require('./routes/generate');
 const eventRoutes = require('./routes/events');
+const changeEventRoutes = require('./routes/change_events');
 app.use('/api/events', eventRoutes);
 app.use('/api/generate', generateRoutes);
+app.use('/api/generate_change_events', changeEventRoutes);
 // SOP generation proxy
 const sopRoutes = require('./routes/sop');
 app.use('/api/generate_sop', sopRoutes);

--- a/backend/src/routes/change_events.js
+++ b/backend/src/routes/change_events.js
@@ -1,0 +1,8 @@
+const express = require('express');
+const router = express.Router();
+const changeEventsController = require('../controllers/changeEventsController');
+
+// POST /api/generate_change_events
+router.post('/', changeEventsController.handleGenerateChangeEvents);
+
+module.exports = router;

--- a/gen_service/readme.md
+++ b/gen_service/readme.md
@@ -139,6 +139,25 @@ gen_service/                # Flask-based demo generator service
     }
     ```
 
+- **POST /api/generate_change_events**
+  - Request JSON body:
+    ```json
+    {
+      "org_name": "string",
+      "scenario": "major|partial|well",
+      "itsm_tools": "string (optional)",
+      "observability_tools": "string (optional)",
+      "service_names": "string (optional)"
+    }
+    ```
+  - Response JSON:
+    ```json
+    {
+      "filename": "<scenario>_change_events_<timestamp>.json",
+      "change_events": "<change events JSON>"
+    }
+    ```
+
 - **GET /preview/<org>/<filename>/postman**
   - Export events JSON as a Postman collection for the specified file.
   


### PR DESCRIPTION
## Summary
- add `/api/generate_change_events` route to Flask service
- proxy `/api/generate_change_events` in Node backend
- document new API endpoint

## Testing
- `bash smoke_test.sh` *(fails: /api/generate returned HTTP 000000)*

------
https://chatgpt.com/codex/tasks/task_e_6846e7714eb88326902cda491e14a3d2