### PR TITLE
feat: initialize pnpm monorepo with shared config

### DIFF
--- a/apps/server/.eslintrc.cjs
+++ b/apps/server/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['../../packages/config/eslint.cjs']
+};

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "server",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "test": "echo \"no tests\"",
+    "lint": "eslint .",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21"
+  }
+}

--- a/apps/server/prettier.config.cjs
+++ b/apps/server/prettier.config.cjs
@@ -1,0 +1,1 @@
+module.exports = require('../../packages/config/prettier.cjs');

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,0 +1,12 @@
+import express from 'express';
+
+const app = express();
+const port = Number(process.env.PORT) || 4000;
+
+app.get('/', (_req, res) => {
+  res.send('Hello from server');
+});
+
+app.listen(port, () => {
+  console.log(`Server running on http://localhost:${port}`);
+});

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../packages/config/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/apps/web/.eslintrc.cjs
+++ b/apps/web/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['../../packages/config/eslint.cjs']
+};

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Web</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "web",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -p tsconfig.json && vite build",
+    "test": "echo \"no tests\"",
+    "lint": "eslint .",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.0.0"
+  }
+}

--- a/apps/web/prettier.config.cjs
+++ b/apps/web/prettier.config.cjs
@@ -1,0 +1,1 @@
+module.exports = require('../../packages/config/prettier.cjs');

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+function App() {
+  return <h1>Hello from web</h1>;
+}
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../packages/config/tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  server: { port: 5173 },
+  plugins: [react()]
+});

--- a/apps/worker/.eslintrc.cjs
+++ b/apps/worker/.eslintrc.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['../../packages/config/eslint.cjs']
+};

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "worker",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "test": "echo \"no tests\"",
+    "lint": "eslint .",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/apps/worker/prettier.config.cjs
+++ b/apps/worker/prettier.config.cjs
@@ -1,0 +1,1 @@
+module.exports = require('../../packages/config/prettier.cjs');

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,0 +1,2 @@
+console.log('Worker started');
+setInterval(() => {}, 1000);

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../packages/config/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "crux-2",
+  "version": "1.0.0",
+  "private": true,
+  "packageManager": "pnpm@10.5.2",
+  "scripts": {
+    "dev": "concurrently \"pnpm --filter server dev\" \"pnpm --filter web dev\" \"pnpm --filter worker dev\"",
+    "build": "pnpm -r build",
+    "test": "pnpm -r test",
+    "lint": "pnpm -r lint",
+    "typecheck": "pnpm -r typecheck"
+  },
+  "devDependencies": {
+    "concurrently": "^8.2.2",
+    "typescript": "^5.4.5",
+    "eslint": "^8.57.0",
+    "prettier": "^3.2.5",
+    "@typescript-eslint/parser": "^7.17.0",
+    "@typescript-eslint/eslint-plugin": "^7.17.0",
+    "tsx": "^4.7.1"
+  }
+}

--- a/packages/config/eslint.cjs
+++ b/packages/config/eslint.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier'
+  ],
+  env: {
+    node: true,
+    browser: true,
+    es2022: true
+  }
+};

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@pd-cbell/config",
+  "version": "1.0.0",
+  "private": true
+}

--- a/packages/config/prettier.cjs
+++ b/packages/config/prettier.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  semi: true,
+  singleQuote: true,
+  trailingComma: 'all',
+  tabWidth: 2
+};

--- a/packages/config/tsconfig.base.json
+++ b/packages/config/tsconfig.base.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": "."
+  }
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'apps/*'
+  - 'packages/*'


### PR DESCRIPTION
## Summary
- set up pnpm workspaces for server, web, and worker apps
- add shared TypeScript, ESLint, and Prettier configs
- provide dev/build/test/lint/typecheck scripts across workspaces

## Testing
- `pnpm install` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*
- `pnpm dev` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.5.2.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_689ba5b088788326aa22638983ba8c64