### PR TITLE
feat: add dotenv configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+PD_API_URL=https://api.pagerduty.com
+PD_EVENTS_URL=https://events.pagerduty.com/v2/enqueue
+PD_USER_TOKEN=<set at runtime>
+PD_FROM_EMAIL=<your_email@pagerduty.com>
+MONGODB_URI=mongodb://localhost:27017/pdcrux
+BASE_URL=http://localhost:4000
+WEBHOOK_PUBLIC_BASE_URL=http://localhost:4000
+CRON_TIMEZONE=America/Chicago

--- a/backend/src/controllers/eventController.js
+++ b/backend/src/controllers/eventController.js
@@ -23,8 +23,12 @@ exports.sendEvents = async (req, res) => {
  */
 exports.streamEvents = async (req, res) => {
   const axios = require('axios');
-  const PAGERDUTY_API_URL = 'https://events.pagerduty.com/v2/enqueue';
-  const PAGERDUTY_CHANGE_URL = 'https://events.pagerduty.com/v2/change/enqueue';
+  const PD_EVENTS_URL = process.env.PD_EVENTS_URL || 'https://events.pagerduty.com/v2/enqueue';
+  if (!process.env.PD_EVENTS_URL) {
+    console.warn('PD_EVENTS_URL is not set. Using default https://events.pagerduty.com/v2/enqueue');
+  }
+  const PAGERDUTY_API_URL = PD_EVENTS_URL;
+  const PAGERDUTY_CHANGE_URL = PD_EVENTS_URL.replace('/enqueue', '/change/enqueue');
   // Initialize SSE headers before attempting to load events
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -7,6 +7,23 @@ const app = express();
 // Use PORT env var or default to 5002 to avoid port conflicts on macOS
 const port = process.env.PORT || 5002;
 
+// Warn about missing environment variables but continue to boot
+const requiredEnv = [
+  'PD_API_URL',
+  'PD_EVENTS_URL',
+  'PD_USER_TOKEN',
+  'PD_FROM_EMAIL',
+  'MONGODB_URI',
+  'BASE_URL',
+  'WEBHOOK_PUBLIC_BASE_URL',
+  'CRON_TIMEZONE',
+];
+requiredEnv.forEach((name) => {
+  if (!process.env[name]) {
+    console.warn(`Environment variable ${name} is not set.`);
+  }
+});
+
 // Allow requests only from your frontend at http://localhost:3000
 // Allow the demo UI (Flask or React) to call this API
 const corsOptions = {

--- a/backend/src/services/eventService.js
+++ b/backend/src/services/eventService.js
@@ -6,10 +6,13 @@ if (!faker.datatype || typeof faker.datatype.uuid !== 'function') {
   faker.datatype = faker.datatype || {};
   faker.datatype.uuid = (...args) => faker.string.uuid(...args);
 }
-// PagerDuty Events V2 API endpoint for incident events
-const PAGERDUTY_API_URL = "https://events.pagerduty.com/v2/enqueue";
-// PagerDuty Events V2 API endpoint for change events
-const PAGERDUTY_CHANGE_URL = "https://events.pagerduty.com/v2/change/enqueue";
+// PagerDuty Events V2 API endpoint for incident and change events
+const PD_EVENTS_URL = process.env.PD_EVENTS_URL || "https://events.pagerduty.com/v2/enqueue";
+if (!process.env.PD_EVENTS_URL) {
+  console.warn('PD_EVENTS_URL is not set. Using default https://events.pagerduty.com/v2/enqueue');
+}
+const PAGERDUTY_API_URL = PD_EVENTS_URL;
+const PAGERDUTY_CHANGE_URL = PD_EVENTS_URL.replace('/enqueue', '/change/enqueue');
 
 exports.loadEvents = async (organization, filename) => {
   // For now, read from a file or database as needed.

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,0 +1,6 @@
+const API_BASE = process.env.REACT_APP_API_BASE_URL || 'http://localhost:5002/api';
+if (!process.env.REACT_APP_API_BASE_URL) {
+  console.warn('REACT_APP_API_BASE_URL is not set. Falling back to http://localhost:5002/api');
+}
+export default API_BASE;
+

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import axios from 'axios';
+import API_BASE from '../config';
 import { promptTemplates } from '../promptTemplates';
 
 function Dashboard() {
@@ -95,7 +96,7 @@ function Dashboard() {
     setIsLoading(true);
 
     try {
-      const response = await axios.post("http://localhost:5002/api/generate", payload);
+      const response = await axios.post(`${API_BASE}/generate`, payload);
       // Backend completed generation
       setGenerationResult(response.data.message || "Generation complete.");
       // Move to last step

--- a/frontend/src/pages/Diagnostics.js
+++ b/frontend/src/pages/Diagnostics.js
@@ -1,8 +1,7 @@
 // frontend/src/pages/Diagnostics.js
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
-
-const API_BASE = 'http://localhost:5002/api';
+import API_BASE from '../config';
 
 const Diagnostics = () => {
   const [organizations, setOrganizations] = useState([]);

--- a/frontend/src/pages/EventSender.js
+++ b/frontend/src/pages/EventSender.js
@@ -1,6 +1,7 @@
 // frontend/src/pages/EventSender.js
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
+import API_BASE from '../config';
 
 const EventSender = () => {
   /**
@@ -55,7 +56,7 @@ const EventSender = () => {
 
   useEffect(() => {
     // Fetch organizations from backend API
-    axios.get('http://localhost:5002/api/organizations')
+    axios.get(`${API_BASE}/organizations`)
       .then((res) => setOrganizations(res.data.organizations))
       .catch((err) => console.error(err));
   }, []);
@@ -76,7 +77,7 @@ const EventSender = () => {
   const handleOrgChange = (e) => {
     setSelectedOrg(e.target.value);
     // Fetch event files for the selected organization
-    axios.get(`http://localhost:5002/api/files/${e.target.value}`)
+    axios.get(`${API_BASE}/files/${e.target.value}`)
       .then((res) => setFiles(res.data.files))
       .catch((err) => console.error(err));
   };
@@ -112,7 +113,7 @@ const EventSender = () => {
         routing_key: routingKey,
       });
       const source = new EventSource(
-        `http://localhost:5002/api/events/stream?${params.toString()}`
+        `${API_BASE}/events/stream?${params.toString()}`
       );
       source.addEventListener('schedule', (e) => {
         try {
@@ -134,7 +135,7 @@ const EventSender = () => {
         routing_key: changeRoutingKey,
       });
       const source = new EventSource(
-        `http://localhost:5002/api/events/stream?${params.toString()}`
+        `${API_BASE}/events/stream?${params.toString()}`
       );
       source.addEventListener('schedule', (e) => {
         try {
@@ -165,7 +166,7 @@ const EventSender = () => {
       routing_key: changeRoutingKey,
     });
     const source = new EventSource(
-      `http://localhost:5002/api/events/stream?${params.toString()}`
+      `${API_BASE}/events/stream?${params.toString()}`
     );
     source.addEventListener('schedule', (e) => {
       try {

--- a/frontend/src/pages/Preview.js
+++ b/frontend/src/pages/Preview.js
@@ -1,6 +1,7 @@
 // frontend/src/pages/Preview.js
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
+import API_BASE from '../config';
 import SimpleMDE from 'react-simplemde-editor';
 // EasyMDE CSS (peer of react-simplemde-editor)
 import 'easymde/dist/easymde.min.css';
@@ -18,13 +19,13 @@ const Preview = () => {
 
   useEffect(() => {
     // Fetch list of organizations
-    axios.get('http://localhost:5002/api/organizations')
+    axios.get(`${API_BASE}/organizations`)
       .then((res) => setOrganizations(res.data.organizations))
       .catch((err) => console.error(err));
   }, []);
 
   const fetchFiles = (org) => {
-    axios.get(`http://localhost:5002/api/files/${org}`)
+    axios.get(`${API_BASE}/files/${org}`)
       .then((res) => setFiles(res.data.files))
       .catch((err) => console.error(err));
   };
@@ -36,7 +37,7 @@ const Preview = () => {
 
   const handleFileSelect = (file) => {
     setSelectedFile(file);
-    axios.get(`http://localhost:5002/api/preview/${selectedOrg}/${file}`)
+    axios.get(`${API_BASE}/preview/${selectedOrg}/${file}`)
       .then((res) => {
         setContent(res.data.content);
       })
@@ -44,7 +45,7 @@ const Preview = () => {
   };
 
   const handleSave = () => {
-    axios.post(`http://localhost:5002/api/preview/${selectedOrg}/${selectedFile}`, { content })
+    axios.post(`${API_BASE}/preview/${selectedOrg}/${selectedFile}`, { content })
       .then(() => alert('File saved successfully!'))
       .catch((err) => console.error(err));
   };
@@ -105,7 +106,7 @@ const Preview = () => {
               className="btn btn-primary ml-2"
               onClick={() =>
                 window.open(
-                  `http://localhost:5002/api/download/${selectedOrg}/${selectedFile}`,
+                  `${API_BASE}/download/${selectedOrg}/${selectedFile}`,
                   '_blank'
                 )
               }
@@ -118,7 +119,7 @@ const Preview = () => {
                 className="btn btn-info ml-2"
                 onClick={() =>
                   window.open(
-                    `http://localhost:5002/api/postman/${selectedOrg}/${selectedFile}`,
+                    `${API_BASE}/postman/${selectedOrg}/${selectedFile}`,
                     '_blank'
                   )
                 }

--- a/frontend/src/pages/SopGenerator.js
+++ b/frontend/src/pages/SopGenerator.js
@@ -1,8 +1,7 @@
 // frontend/src/pages/SopGenerator.js
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
-
-const API_BASE = 'http://localhost:5002/api';
+import API_BASE from '../config';
 
 const SopGenerator = () => {
   const [organizations, setOrganizations] = useState([]);

--- a/gen_service/app.py
+++ b/gen_service/app.py
@@ -1,5 +1,7 @@
 from flask import Flask, render_template, request, send_from_directory, redirect, url_for, make_response
 import json
+from dotenv import load_dotenv
+load_dotenv()
 from event_sender import event_sender, get_files, event_sender_summary, event_sender_send, load_event_file, PAGERDUTY_API_URL
 from sop_generator import generate_sop, generate_sop_blended
 from diagnostic_generator import generate_diagnostics
@@ -16,6 +18,21 @@ app.add_url_rule('/get_files/<org>', 'get_files', get_files)
 app.add_url_rule('/event_sender', 'event_sender', event_sender, methods=['GET', 'POST'])
 app.add_url_rule('/event_sender/summary', 'event_sender_summary', event_sender_summary, methods=['POST'])
 app.add_url_rule('/event_sender/send', 'event_sender_send', event_sender_send, methods=['POST'])
+
+# Warn about missing environment variables
+REQUIRED_ENV = [
+    'PD_API_URL',
+    'PD_EVENTS_URL',
+    'PD_USER_TOKEN',
+    'PD_FROM_EMAIL',
+    'MONGODB_URI',
+    'BASE_URL',
+    'WEBHOOK_PUBLIC_BASE_URL',
+    'CRON_TIMEZONE',
+]
+for name in REQUIRED_ENV:
+    if not os.getenv(name):
+        app.logger.warning(f"Environment variable {name} is not set.")
 
 # Ensure the main generated_files folder exists
 if not os.path.exists(app.config['GENERATED_FOLDER']):

--- a/gen_service/event_sender.py
+++ b/gen_service/event_sender.py
@@ -4,8 +4,14 @@ import logging
 import requests
 import time
 from flask import Flask, render_template, request, redirect, url_for, jsonify
+from dotenv import load_dotenv
 
-PAGERDUTY_API_URL = "https://events.pagerduty.com/v2/enqueue"
+load_dotenv()
+
+PD_EVENTS_URL = os.getenv('PD_EVENTS_URL', 'https://events.pagerduty.com/v2/enqueue')
+if not os.getenv('PD_EVENTS_URL'):
+    logging.warning('PD_EVENTS_URL is not set. Using default https://events.pagerduty.com/v2/enqueue')
+PAGERDUTY_API_URL = PD_EVENTS_URL
 # Store generated files in the backend service directory so Node backend and Preview UIs share the same files
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'backend', 'generated_files'))
 GENERATED_FOLDER = BASE_DIR

--- a/gen_service/requirements.txt
+++ b/gen_service/requirements.txt
@@ -4,3 +4,4 @@ langchain
 openai
 langchain_community
 Faker>=13.3.4
+python-dotenv


### PR DESCRIPTION
## Summary
- provide .env.example with PagerDuty and service defaults
- load environment variables and warn when missing in backend and gen_service
- front-end requests now use API base URL from environment

## Testing
- `npm test` *(backend: Missing script "test")*
- `npm test` *(frontend: Cannot find module 'react-router-dom')*
- `python -m py_compile app.py event_sender.py`


------
https://chatgpt.com/codex/tasks/task_e_689ba5ddcd64832695cfcb3fd8e01034